### PR TITLE
Add HedgeDoc name history

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,9 @@ HedgeDoc is a real-time collaborative word processing web service. It uses Markd
 
 **Shipped version:** 1.7.2
 
+**NB:** HedgeDoc is a former HackMD fork, called CodiMD, that was renamed HedgeDoc : https://hedgedoc.org/history/
+This is *not* the currently called CodiMD software.
+
 ## Screenshots
 
 ![](https://demo.hedgedoc.org/screenshot.png)

--- a/README_fr.md
+++ b/README_fr.md
@@ -12,6 +12,8 @@ Si vous n'avez pas YunoHost, consultez [le guide](https://yunohost.org/#/install
 HedgeDoc est un service web de traitement de texte collaboratif en temps réel. Il utilise le langage Markdown.
 
 **Version incluse :** 1.7.2
+**NB:** HedgeDoc est l'ancier fork d'HackMD, nommé CodiMD, qui a été renommé HedgeDoc : https://hedgedoc.org/history/
+Ce n'est *pas* le logiciel actuellement appelé CodiMD.
 
 ## Captures d'écran
 


### PR DESCRIPTION
## Problem
- We need to explain that we install HedgeDoc, not CodiMD, and the whole mess about HackMD/CodiMD/HedgeDoc.
Fix #1 